### PR TITLE
feat(port): port argument used

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -15,7 +15,8 @@ import { viwiLogger } from "./log";
  */
 const commandLineArgs = require('command-line-args')
 const optionDefinitions = [
-  { name: 'verbosity', alias: 'v', type: String }
+  { name: 'verbosity', alias: 'v', type: String },
+  { name: 'port', alias: 'p', type: Number }
 ]
 const cla = commandLineArgs(optionDefinitions);
 /** end parse command line argunments */
@@ -36,7 +37,7 @@ var server:WebServer;
 
 var run = (port?:number):Promise<void> => {
   return new Promise<void>((resolve, reject) => {
-    server = new WebServer(port);
+    server = new WebServer(cla.port);
     server.init(); // need to init
 
     server.app.get(BASEURI, (req: express.Request, res: express.Response, next: express.NextFunction) => {


### PR DESCRIPTION
Port argument (--port) can be used to set port for the http socket of the ViWi server